### PR TITLE
Added Postgresql support

### DIFF
--- a/Shuttle.Esb.Sql.Subscription/.scripts/Npgsql/SubscriptionManagerContains.sql
+++ b/Shuttle.Esb.Sql.Subscription/.scripts/Npgsql/SubscriptionManagerContains.sql
@@ -1,0 +1,1 @@
+select (exists (select 1 from subscriber_message_type where inbox_work_queue_uri = :InboxWorkQueueUri and message_type = :MessageType))::int

--- a/Shuttle.Esb.Sql.Subscription/.scripts/Npgsql/SubscriptionManagerCreate.sql
+++ b/Shuttle.Esb.Sql.Subscription/.scripts/Npgsql/SubscriptionManagerCreate.sql
@@ -1,0 +1,11 @@
+CREATE TABLE public.subscriber_message_type
+(
+  message_type character varying(250) NOT NULL,
+  inbox_work_queue_uri character varying(130) NOT NULL,
+  CONSTRAINT pk_subscriber_message_type PRIMARY KEY (message_type, inbox_work_queue_uri)
+)
+WITH (
+  OIDS=FALSE
+);
+ALTER TABLE public.subscriber_message_type
+  OWNER TO postgres;

--- a/Shuttle.Esb.Sql.Subscription/.scripts/Npgsql/SubscriptionManagerExists.sql
+++ b/Shuttle.Esb.Sql.Subscription/.scripts/Npgsql/SubscriptionManagerExists.sql
@@ -1,0 +1,1 @@
+select (exists (select 1 from pg_tables where schemaname = 'public' and tablename = 'subscriber_message_type'))::int

--- a/Shuttle.Esb.Sql.Subscription/.scripts/Npgsql/SubscriptionManagerInboxWorkQueueUris.sql
+++ b/Shuttle.Esb.Sql.Subscription/.scripts/Npgsql/SubscriptionManagerInboxWorkQueueUris.sql
@@ -1,0 +1,1 @@
+select inbox_work_queue_uri as InboxWorkQueueUri from subscriber_message_type where message_type = :MessageType

--- a/Shuttle.Esb.Sql.Subscription/.scripts/Npgsql/SubscriptionManagerSubscribe.sql
+++ b/Shuttle.Esb.Sql.Subscription/.scripts/Npgsql/SubscriptionManagerSubscribe.sql
@@ -1,0 +1,8 @@
+insert into subscriber_message_type (inbox_work_queue_uri, message_type) 
+select :InboxWorkQueueUri, :MessageType
+where not exists (select 1 
+                  from subscriber_message_type 
+				  where 
+				    inbox_work_queue_uri = :InboxWorkQueueUri 
+				    and message_type = :MessageType)
+

--- a/Shuttle.Esb.Sql.Subscription/Shuttle.Esb.Sql.Subscription.csproj
+++ b/Shuttle.Esb.Sql.Subscription/Shuttle.Esb.Sql.Subscription.csproj
@@ -145,6 +145,17 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include=".scripts\Npgsql\SubscriptionManagerContains.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include=".scripts\Npgsql\SubscriptionManagerCreate.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include=".scripts\Npgsql\SubscriptionManagerExists.sql" />
+    <EmbeddedResource Include=".scripts\Npgsql\SubscriptionManagerInboxWorkQueueUris.sql" />
+    <EmbeddedResource Include=".scripts\Npgsql\SubscriptionManagerSubscribe.sql" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
I have added support for Postgresql by adding embedded sql-scripts.
These can be uses by setting the providername to 'Npgsql' in the connectionstring.
The DbProviderFactory-meganism then automatically takes care of the rest.

To get this working one first needs to configure the Npgsql DbProviderFactory. This is accomplished by adding this to the .config file:
```
  <system.data>
    <DbProviderFactories>
      <add name="Npgsql Data Provider" invariant="Npgsql" support="FF" description=".Net Framework Data Provider for Postgresql" type="Npgsql.NpgsqlFactory, Npgsql" />
    </DbProviderFactories>
  </system.data>

```
The altered connection string looks like this:
`<add name="Subscription" connectionString="Server=localhost;Port=5432;Database=ShuttleEsb;User Id=postgres;Password=password;" providerName="Npgsql"/>
`
That's all there is to it.


