### PR TITLE
Cache subscribers for a fixed amount of time

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The configuration section is optional as the defaults will be applied when no se
 	<subscription
 		connectionStringName="Subscription"
 		subscribe="Normal|Ensure|Ignore"
+		cacheTimeout="0.0:5:0"
 	/>
   .
   .
@@ -42,6 +43,7 @@ The configuration section is optional as the defaults will be applied when no se
 | --- | --- | --- |
 | `connectionStringName`	 | Subscription | The name of the `connectionString` to use to connect to the subscription store. |
 | `subscribe`	| Normal | Indicates how calls to the `Subscribe` method are dealt with: <br/>- `Normal` is the ***default*** and will subscribe to the given message type(s) if they have not been subscribed to yet.<br/>- `Ensure` will check to see that the subscription exists and if not will throw an `ApplicationException`.<br/>- `Ignore` will simply ignore the subscription request. |
+| `cacheTimeout`          |  0.0:5:0      | How long event subscribers should be cached for before refetching them from the database. |
 
 Whenever the endpoint is configured as a worker no new subscriptions will be registered against the endpoint since any published events should be subscribed to only by the distributor endpoint.  When using a broker such as RabbitMQ all the endpoints feed off the same work queue uri and any of the endpoints could create the subscription.
 

--- a/Shuttle.Esb.Sql.Subscription.Tests/SectionFixture.cs
+++ b/Shuttle.Esb.Sql.Subscription.Tests/SectionFixture.cs
@@ -24,6 +24,7 @@ namespace Shuttle.Esb.Sql.Subscription.Tests
 
 			Assert.AreEqual("connection-string-name", section.ConnectionStringName);
 			Assert.AreEqual(SubscribeOption.Ensure, section.Subscribe);
+			Assert.AreEqual(TimeSpan.FromMinutes(10), section.CacheTimeout);
 		}
 	}
 }

--- a/Shuttle.Esb.Sql.Subscription.Tests/Shuttle.Esb.Sql.Subscription.Tests.csproj
+++ b/Shuttle.Esb.Sql.Subscription.Tests/Shuttle.Esb.Sql.Subscription.Tests.csproj
@@ -9,7 +9,7 @@
         <PackageReference Include="Moq" Version="4.17.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="Shuttle.Core.Data" Version="12.0.1" />
+        <PackageReference Include="Shuttle.Core.Data" Version="12.0.2" />
         <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
     </ItemGroup>
 

--- a/Shuttle.Esb.Sql.Subscription.Tests/files/Subscription-Grouped.config
+++ b/Shuttle.Esb.Sql.Subscription.Tests/files/Subscription-Grouped.config
@@ -7,8 +7,9 @@
 	</configSections>
 
 	<shuttle>
-    <subscription
+		<subscription
 			connectionStringName="connection-string-name"
-      subscribe="Ensure" />
+			subscribe="Ensure" 
+			cacheTimeout="0.0:10:0" />
 	</shuttle>
 </configuration>

--- a/Shuttle.Esb.Sql.Subscription.Tests/files/Subscription.config
+++ b/Shuttle.Esb.Sql.Subscription.Tests/files/Subscription.config
@@ -6,5 +6,6 @@
 
   <subscription
     connectionStringName="connection-string-name"
-    subscribe="Ensure" />
+    subscribe="Ensure"
+	cacheTimeout="0.0:10:0" />
 </configuration>

--- a/Shuttle.Esb.Sql.Subscription/ISubscriptionConfiguration.cs
+++ b/Shuttle.Esb.Sql.Subscription/ISubscriptionConfiguration.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Shuttle.Esb.Sql.Subscription
 {
 	public interface ISubscriptionConfiguration
@@ -5,5 +7,6 @@ namespace Shuttle.Esb.Sql.Subscription
 		string ProviderName { get; }
 		string ConnectionString { get; }
 		SubscribeOption Subscribe { get; }
+		TimeSpan CacheTimeout { get; }
 	}
 }

--- a/Shuttle.Esb.Sql.Subscription/Shuttle.Esb.Sql.Subscription.csproj
+++ b/Shuttle.Esb.Sql.Subscription/Shuttle.Esb.Sql.Subscription.csproj
@@ -39,6 +39,7 @@
         <PackageReference Include="Shuttle.Core.Data" Version="12.0.2" />
         <PackageReference Include="Shuttle.Esb" Version="12.0.1" />
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+        <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Shuttle.Esb.Sql.Subscription/SubscriptionConfiguration.cs
+++ b/Shuttle.Esb.Sql.Subscription/SubscriptionConfiguration.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Shuttle.Esb.Sql.Subscription
 {
     public enum SubscribeOption
@@ -12,10 +14,12 @@ namespace Shuttle.Esb.Sql.Subscription
 		public SubscriptionConfiguration()
 		{
 		    Subscribe = SubscribeOption.Normal;
+		    CacheTimeout = TimeSpan.FromMinutes(5);
 		}
 
 	    public string ProviderName { get; set; }
 	    public string ConnectionString { get; set; }
 		public SubscribeOption Subscribe { get; set; }
+		public TimeSpan CacheTimeout { get; set; }
 	}
 }

--- a/Shuttle.Esb.Sql.Subscription/SubscriptionSection.cs
+++ b/Shuttle.Esb.Sql.Subscription/SubscriptionSection.cs
@@ -12,6 +12,9 @@ namespace Shuttle.Esb.Sql.Subscription
         [ConfigurationProperty("subscribe", IsRequired = false, DefaultValue = SubscribeOption.Normal)]
         public SubscribeOption Subscribe => (SubscribeOption) this["subscribe"];
 
+        [ConfigurationProperty("cacheTimeout", IsRequired = false, DefaultValue = "0.0:5:0")]
+        public TimeSpan CacheTimeout => (TimeSpan) this["cacheTimeout"]; 
+
         public static SubscriptionConfiguration Configuration()
         {
             var section = ConfigurationSectionProvider.Open<SubscriptionSection>("shuttle", "subscription");
@@ -23,6 +26,7 @@ namespace Shuttle.Esb.Sql.Subscription
             {
                 connectionStringName = section.ConnectionStringName;
                 configuration.Subscribe = section.Subscribe;
+                configuration.CacheTimeout = section.CacheTimeout;
             }
 
             var settings = ConfigurationManager.ConnectionStrings[connectionStringName];


### PR DESCRIPTION
Hi, I don't know if you accept PR's or think this is the best way to fix this issue, but currently subscribers are cached in memory until the application is restarted. This makes adding new subscribers a bit annoying as you need to ensure the publishing application is restarted otherwise they will never receive any messages.

This change caches the subscribers for a absolute amount of time (5 minutes by default) so that new subscribers will be picked up in a timely fashion.